### PR TITLE
don't search in markdown, search in the rendered page

### DIFF
--- a/SearchBox.vue
+++ b/SearchBox.vue
@@ -199,21 +199,19 @@ export default {
       const queryPosition = page.content.toLowerCase().indexOf(this.query)
       const startIndex = queryPosition - 20 < 0 ? 0 : queryPosition - 20
       const endIndex = queryPosition + 30
-      let querySnippet = page.content.slice(startIndex, endIndex)
-        .toLowerCase()
-        .replace(/[\W_]+/g, " ")
+      const querySnippet = page.content.slice(startIndex, endIndex)
 
-      const queryWords = this.query.split(' ').filter((v, i, a) => !!v && a.indexOf(v) === i); 
+      const queryWords = this.query.toLowerCase().split(' ').filter((v, i, a) => !!v && a.indexOf(v) === i); 
 
       let highlightedSnippet = ""
       for (let i = 0; i < querySnippet.length;) {
-        const remainingSnippet = querySnippet.slice(i)
-        const matchingWord = queryWords.find(word => querySnippet.slice(i).startsWith(word))
+        const matchingWord = queryWords.find(word => querySnippet.toLowerCase().startsWith(word, i))
         if (matchingWord === undefined) {
           highlightedSnippet += querySnippet[i]
           i += 1
         } else {
-          highlightedSnippet += `<strong class="text--primary">${matchingWord}</strong>`
+          const highlightedWord = querySnippet.slice(i, i + matchingWord.length)
+          highlightedSnippet += `<strong class="text--primary">${highlightedWord}</strong>`
           i += matchingWord.length
         }
       }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = (options) => ({
         // _strippedContent does not contain the YAML frontmatter
         const { html } = $page._context.markdown.render($page._strippedContent)
         const text = html
-            .replace(/<[^>]+>/g, "") // remove HTML tags
+            .replace(/(<[^>]+>)+/g, " ") // remove HTML tags
             .replace(/^\s*#\s/gm, "") // remove header anchors inserted by vuepress
         $page.content = text
     },

--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ const { path } = require('@vuepress/shared-utils')
 
 module.exports = (options) => ({
     extendPageData ($page) {
-        const {
-            _content
-        } = $page
-        $page.content = _content.replace(/<[^>]+>/g, " ")
+        // _strippedContent does not contain the YAML frontmatter
+        const { html } = $page._context.markdown.render($page._strippedContent)
+        const text = html
+            .replace(/<[^>]+>/g, "") // remove HTML tags
+            .replace(/^\s*#\s/gm, "") // remove header anchors inserted by vuepress
+        $page.content = text
     },
     alias: {
         '@SearchBox':

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ const { path } = require('@vuepress/shared-utils')
 
 module.exports = (options) => ({
     extendPageData ($page) {
+        if (!$page._strippedContent) {
+            return
+        }
         // _strippedContent does not contain the YAML frontmatter
         const { html } = $page._context.markdown.render($page._strippedContent)
         const text = html


### PR DESCRIPTION
fixes #13

This pull request changes the search input (and thus also the preview input): we first render the markdown to HTML, then strip the HTML tags.

Additionally, it changes the preview so it preserves casing.
Plus, it no longer searches the YAML frontmatter of each page. The frontmatter is not visible to the user, so search hits there can be confusing as the user won't find the text on the page.

This is what the preview looks like after this change:

![image](https://user-images.githubusercontent.com/38839/79635716-e1a28200-8172-11ea-86e1-bf6d9cc88225.png)

![image](https://user-images.githubusercontent.com/38839/79635733-f54de880-8172-11ea-9506-c3e4383fc32e.png)

Since this change causes the flexsearch plugin to render all markdown files again so it can index them, I timed how much overhead this generates. On our code base with 103 md files (most medium-sized, some large), I did not find any increase in the time between starting vuepress and the pages being rendered in dev mode (both with and without the change took ~22s). So I think it's safe to say that this change keeps the plugin performant :-)