### PR TITLE
Split highlighted words with flexsearch delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module.exports = {
         searchHotkeys: ['s'],    // Hot keys to activate the search input, the default is "s" but you can add more.
         searchResultLength: 60,    // the length of the suggestion result text by characters, the default is 60 characters.
         splitHighlightedWords: ' ',  // regex or string to split highlighted words by, keep it null to use flexsearch.split
+        noExtraSpaceAfterHtmlTag: false,   // don't add extra spaces in highlighted results
         /*
           Default FlexSearch options
           To override the default options you can see available options at https://github.com/nextapps-de/flexsearch

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ module.exports = {
         searchPaths: ['path1', 'path2'],    // an array of paths to search in, keep it null to search all docs.
         searchHotkeys: ['s'],    // Hot keys to activate the search input, the default is "s" but you can add more.
         searchResultLength: 60,    // the length of the suggestion result text by characters, the default is 60 characters.
+        splitHighlightedWords: ' ',  // regex or string to split highlighted words by, keep it null to use flexsearch.split
         /*
           Default FlexSearch options
           To override the default options you can see available options at https://github.com/nextapps-de/flexsearch

--- a/index.js
+++ b/index.js
@@ -27,5 +27,6 @@ module.exports = (options) => ({
     SEARCH_HOTKEYS: options.searchHotkeys || "s",
     SEARCH_RESULT_LENGTH:
       Number(options.searchResultLength) || DEFAULT_SEARCH_RESULT_LENGTH,
+    SEARCH_SPLIT_HIGHLIGHTED_WORDS: options.splitHighlightedWords || null,
   },
 });

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const DEFAULT_SEARCH_RESULT_LENGTH = 60;
 
 module.exports = (options) => ({
   extendPageData($page) {
-    $page.content = getPageText($page);
+    $page.content = getPageText($page, options.noExtraSpaceAfterHtmlTag);
   },
   alias: {
     "@SearchBox": path.resolve(__dirname, "src", "SearchBox.vue"),

--- a/src/SearchBox.vue
+++ b/src/SearchBox.vue
@@ -56,6 +56,7 @@ SEARCH_PATHS
 SEARCH_HOTKEYS
 SEARCH_OPTIONS
 SEARCH_RESULT_LENGTH
+SEARCH_SPLIT_HIGHLIGHTED_WORDS
 */
 export default {
   extends: VuepressSearchBox,
@@ -84,6 +85,10 @@ export default {
         });
 
       return result;
+    },
+
+    splitBy() {
+      return SEARCH_SPLIT_HIGHLIGHTED_WORDS || this.index.split;
     },
   },
 
@@ -115,7 +120,7 @@ export default {
 
     getSuggestionTitle(page) {
       const title = page.title ? page.title : page.regularPath;
-      return highlightText(title, this.query);
+      return highlightText(title, this.query, this.splitBy);
     },
 
     getSuggestionText(page) {
@@ -123,7 +128,7 @@ export default {
       const queryIndex = content
         .toLowerCase()
         .indexOf(this.query.toLowerCase());
-      const queryFirstWord = this.query.split(" ")[0];
+      const queryFirstWord = this.query.split(this.splitBy)[0];
       let startIndex =
         queryIndex === -1
           ? content.toLowerCase().indexOf(queryFirstWord.toLowerCase())
@@ -134,7 +139,7 @@ export default {
         prefix = ".. ";
       }
       const text = page.content.substr(startIndex, SEARCH_RESULT_LENGTH);
-      return prefix + highlightText(text, this.query);
+      return prefix + highlightText(text, this.query, this.splitBy);
     },
   },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@ const he = require("he");
  * @param  page
  * @returns {string}
  */
-module.exports.getPageText = (page) => {
+module.exports.getPageText = (page, noExtraSpaceAfterHtmlTag) => {
   if (!page._strippedContent) {
     return "";
   }
@@ -14,7 +14,7 @@ module.exports.getPageText = (page) => {
   const text = he.decode(
     // decode HTML entities like &quot;
     html
-      .replace(/(<[^>]+>)+/g, " ") // remove HTML tags
+      .replace(/(<[^>]+>)+/g, noExtraSpaceAfterHtmlTag ? "" : " ") // remove HTML tags
       .replace(/^\s*#\s/gm, "") // remove header anchors inserted by vuepress
   );
   return text;

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,9 +29,9 @@ function escapeRegExp(string) {
  * @param  {string} highlightTarget
  * @returns {string}
  */
-module.exports.highlightText = (fullText, highlightTarget) => {
+module.exports.highlightText = (fullText, highlightTarget, splitBy) => {
   let result = fullText;
-  highlightWords = highlightTarget.split(" ").filter((word) => word.length > 0);
+  highlightWords = highlightTarget.split(splitBy).filter((word) => word.length > 0);
   if (highlightWords.length > 0) {
     for (const word of highlightWords) {
       result = result.replace(new RegExp(escapeRegExp(word), "ig"), "<em>$&</em>");

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,7 @@ module.exports.getPageText = (page, noExtraSpaceAfterHtmlTag) => {
   const text = he.decode(
     // decode HTML entities like &quot;
     html
-      .replace(/(<[^>]+>)+/g, noExtraSpaceAfterHtmlTag ? "" : " ") // remove HTML tags
+      .replace(/<[^>]*(>|$)/g, noExtraSpaceAfterHtmlTag ? "" : " ") // remove HTML tags
       .replace(/^\s*#\s/gm, "") // remove header anchors inserted by vuepress
   );
   return text;


### PR DESCRIPTION
Flexsearch's split defaults to `/[\W_]+/`, not `" "`: https://github.com/nextapps-de/flexsearch#charset-options

Quick comparison of searching for code
| Before | After | After (without spaces) |
| --- | --- | --- |
| ![before](https://user-images.githubusercontent.com/3758846/129988304-5b906143-8167-488c-ae64-b6be6383ef52.png) | ![new default](https://user-images.githubusercontent.com/3758846/129988308-4e926e0e-5cad-4516-a0ee-d65460f41206.png) | ![new both](https://user-images.githubusercontent.com/3758846/129988307-bce3d126-3aea-4b78-867e-413f89defed7.png) |

- Before:
![old](https://user-images.githubusercontent.com/3758846/129986727-6ec545d1-5d36-491f-a4f5-f5f218330fba.gif)
  
  configuration to keep this behaviour:
  ```js
    splitHighlightedWords: ' ',
  /*noExtraSpaceAfterHtmlTag: false,  // default */
  ```

- After:
![new default](https://user-images.githubusercontent.com/3758846/129986856-41428565-91f7-4a1f-aad0-f2e9094f7200.gif)

  this is new default
  ```js
  /*splitHighlightedWords: null,  // default */
  /*noExtraSpaceAfterHtmlTag: false,  // default */
  ```

- After (without spaces):
![new both](https://user-images.githubusercontent.com/3758846/129987005-03ab40c6-7bfd-4eaa-8c9b-fdecae73fefa.gif)

  I didn't make this default because I'm not sure if it concatenates words in any use case. But it works best
  ```js
  /*splitHighlightedWords: null,  // default */
    noExtraSpaceAfterHtmlTag: true,
  ```