### PR TITLE
Emphasys tags problem when search by  letters 'E' or 'M' after another word

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,8 +20,13 @@ module.exports.getPageText = (page) => {
   return text;
 };
 
-function escapeRegExp(string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function normalizeString(string) {
+  return string.replace(/<|>/g, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function generateRegExp(string) {
+  const stringNormalized = normalizeString(string);
+  return `(?<!</?[^>]*|&[^;]*)${stringNormalized}`;
 }
 
 /**
@@ -34,10 +39,10 @@ module.exports.highlightText = (fullText, highlightTarget) => {
   highlightWords = highlightTarget.split(" ").filter((word) => word.length > 0);
   if (highlightWords.length > 0) {
     for (const word of highlightWords) {
-      result = result.replace(new RegExp(escapeRegExp(word), "ig"), "<em>$&</em>");
+      result = result.replace(new RegExp(generateRegExp(word), "ig"), "<em>$&</em>");
     }
   } else {
-    result = fullText.replace(new RegExp(escapeRegExp(highlightTarget), "ig"), "<em>$&</em>");
+    result = fullText.replace(new RegExp(generateRegExp(highlightTarget), "ig"), "<em>$&</em>");
   }
 
   return result;


### PR DESCRIPTION
When we type 'E' or 'M' after another word already searched, a unespected behavior happens:

![image](https://user-images.githubusercontent.com/32545608/186907168-0d03caf8-4c9c-478c-832b-58b2ee8565e8.png)

It happens, because the code replaces these letters considering the tags <em> created for the other words searched.

I created a development proposal to not cosidered the find inside HTML tags.